### PR TITLE
BaseEnum class rewrite

### DIFF
--- a/UPGRADE-2.0.md
+++ b/UPGRADE-2.0.md
@@ -1,0 +1,6 @@
+Upgrade from 1.x to 2.0
+=======================
+
+### BaseEnum class update
+
+* `getConstants`, `isValidName` and `isValidValue` methods are now final.

--- a/UPGRADE-2.0.md
+++ b/UPGRADE-2.0.md
@@ -4,3 +4,5 @@ Upgrade from 1.x to 2.0
 ### BaseEnum class update
 
 * `getConstants`, `isValidName` and `isValidValue` methods are now final.
+* The `Greg0ire\Enum\BaseEnum::isValidName` method does not have a `$strict` argument anymore.
+All verifications will be strict now.

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.1.x-dev"
+            "dev-master": "2.x-dev"
         }
     },
     "suggest": {

--- a/src/BaseEnum.php
+++ b/src/BaseEnum.php
@@ -45,21 +45,12 @@ abstract class BaseEnum
      * Checks whether a constant with this name is defined.
      *
      * @param string  $name   the name of the constant
-     * @param boolean $strict whether to make a case sensitive check
      *
      * @return boolean the result of the test
      */
-    final public static function isValidName($name, $strict = false)
+    final public static function isValidName($name)
     {
-        $constants = self::getConstants();
-
-        if ($strict) {
-            return array_key_exists($name, $constants);
-        }
-
-        $keys = array_map('strtolower', array_keys($constants));
-
-        return in_array(strtolower($name), $keys);
+        return array_key_exists($name, self::getConstants());
     }
 
     /**

--- a/src/BaseEnum.php
+++ b/src/BaseEnum.php
@@ -13,7 +13,7 @@ abstract class BaseEnum
      * @return array a hash with your constants and their value. Useful for
      *               building a choice widget
      */
-    public static function getConstants()
+    final public static function getConstants()
     {
         $enumTypes = static::getEnumTypes();
         $enums     = array();
@@ -49,7 +49,7 @@ abstract class BaseEnum
      *
      * @return boolean the result of the test
      */
-    public static function isValidName($name, $strict = false)
+    final public static function isValidName($name, $strict = false)
     {
         $constants = self::getConstants();
 
@@ -71,7 +71,7 @@ abstract class BaseEnum
      * @return bool the result of the test
      *
      */
-    public static function isValidValue($value, $strict = true)
+    final public static function isValidValue($value, $strict = true)
     {
         $values = array_values(self::getConstants());
 

--- a/test/BaseEnumTest.php
+++ b/test/BaseEnumTest.php
@@ -76,8 +76,7 @@ class BaseEnumTest extends \PHPUnit_Framework_TestCase
 
     public function testsIsValidName()
     {
-        $this->assertTrue(DummyEnum::isValidName('fiRsT'));
-        $this->assertFalse(DummyEnum::isValidName('fiRsT', true));
+        $this->assertFalse(DummyEnum::isValidName('fiRsT'));
         $this->assertFalse(DummyEnum::isValidName('invalid'));
     }
 


### PR DESCRIPTION
This code rewrite is BC break.

* Removed $strict parameter from `isValidName` method.
* Made `getConstants`, `isValidName` and `isValidValue` final.