### PR TITLE
Add BaseEnum::getKeys

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,13 @@ Additionally, you may get all the constants in your class as a hash:
 DaysOfWeek::getConstants()
 ```
 
+You may also get all the keys in your class as an array:
+
+```php
+DaysOfWeek::getKeys();
+DaysOfWeek::getKeys('strtolower'); // Will call `array_map` with the given callback.
+```
+
 ### Advanced usage
 
 If you need to get the constants from a class you cannot modify, or from an

--- a/src/BaseEnum.php
+++ b/src/BaseEnum.php
@@ -42,6 +42,24 @@ abstract class BaseEnum
     }
 
     /**
+     * Returns constants keys.
+     *
+     * @param callable|null $callback A callable function compatible with array_map
+     *
+     * @return string[]
+     */
+    final public static function getKeys($callback = null)
+    {
+        $keys = array_keys(static::getConstants());
+
+        if (null !== $callback) {
+            return array_map($callback, $keys);
+        }
+
+        return $keys;
+    }
+
+    /**
      * Checks whether a constant with this name is defined.
      *
      * @param string  $name   the name of the constant

--- a/test/BaseEnumTest.php
+++ b/test/BaseEnumTest.php
@@ -74,6 +74,27 @@ class BaseEnumTest extends \PHPUnit_Framework_TestCase
         );
     }
 
+    public function testFooGetKeys()
+    {
+        $this->assertEquals(
+            array(
+                'GOD',
+                'CHUCK',
+                'GUITRY'
+            ),
+            FooEnum::getKeys()
+        );
+
+        $this->assertEquals(
+            array(
+                'god',
+                'chuck',
+                'guitry'
+            ),
+            FooEnum::getKeys('strtolower')
+        );
+    }
+
     public function testsIsValidName()
     {
         $this->assertTrue(DummyEnum::isValidName('fiRsT'));


### PR DESCRIPTION
The goal is to be able to have the constants key list directly.

Will add a not on upgrade once #7 will be merged.