### PR TITLE
Drop PHP 5.3, 5.4 and 5.5 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
 language: php
 
 php:
-  - 5.3
-  - 5.4
-  - 5.5
   - 5.6
   - 7.0
   - hhvm
@@ -12,7 +9,7 @@ php:
 matrix:
   fast_finish: true
   include:
-    - php: 5.3
+    - php: 5.6
       env: COMPOSER_OPTIONS="--prefer-lowest"
   allow_failures:
     - php: nightly

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "sllh/php-cs-fixer-styleci-bridge": "^2.0"
     },
     "require": {
-        "php": "^5.3 || ^7.0"
+        "php": "^5.6 || ^7.0"
     },
     "license": "CC-BY-SA-3.0",
     "authors": [


### PR DESCRIPTION
5.6 is the last current maintained version of PHP.