### PR TITLE
Revert to PSR2

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,4 +1,4 @@
-preset: symfony
+preset: psr2
 
 enabled:
   - newline_after_open_tag


### PR DESCRIPTION
If we use the symfony fixers, people might start to think that we abide
by all the symfony standards, and use Yoda conditions or multiline
signatures. PSR2 has no controversial rules so let us go back to that.