### PR TITLE
Add Symfony 3.2 on failures, 3.1 on normal tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,10 +22,12 @@ matrix:
     - php: 7.0
       env: SYMFONY_VERSION=3.0.*
     - php: 7.0
-      env: SYMFONY_VERSION=3.1.*@dev
+      env: SYMFONY_VERSION=3.1.*
+    - php: 7.0
+      env: SYMFONY_VERSION=3.2.*@dev
   allow_failures:
     - php: nightly
-    - env: SYMFONY_VERSION=3.1.*@dev
+    - env: SYMFONY_VERSION=3.2.*@dev
 
 install:
   - composer global require sllh/composer-lint:@stable --prefer-dist --no-interaction


### PR DESCRIPTION
Symfony 3.1 is stable now.