### PR TITLE
Introduce AbstractEnum::getKeysFromValue

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,14 @@ DaysOfWeek::getClassPrefixedKeys('strtolower'); // Will call `array_map` with th
 DaysOfWeek::getClassPrefixedKeys('strtolower', '.'); // Replace the namespace separator ('_' by default).
 ```
 
+If you would like to get the keys from a value:
+
+```php
+$key = DaysOfWeek::getKeysFromValue(1); // Monday will be assigned to $key
+```
+
+If you have many keys with the same value you will get an array, and a value otherwise.
+
 ### Advanced usage
 
 If you need to get the constants from a class you cannot modify, or from an

--- a/src/AbstractEnum.php
+++ b/src/AbstractEnum.php
@@ -144,4 +144,24 @@ abstract class AbstractEnum
     {
         return [get_called_class()];
     }
+
+    /**
+     * Returns keys from a value.
+     *
+     * @param mixed $value
+     *
+     * @return string|string[]
+     */
+    public static function getKeysFromValue($value)
+    {
+        $keys = [];
+
+        foreach (static::getConstants() as $key => $item) {
+            if ($value === $item) {
+                $keys[] = $key;
+            }
+        }
+
+        return count($keys) === 1 ? current($keys) : $keys;
+    }
 }

--- a/test/AbstractEnumTest.php
+++ b/test/AbstractEnumTest.php
@@ -4,6 +4,7 @@ namespace Greg0ire\Enum\Tests;
 
 use Greg0ire\Enum\Tests\Fixtures\AllEnum;
 use Greg0ire\Enum\Tests\Fixtures\DummyEnum;
+use Greg0ire\Enum\Tests\Fixtures\DummyWithSameValuesEnum;
 use Greg0ire\Enum\Tests\Fixtures\FooEnum;
 
 class AbstractEnumTest extends \PHPUnit_Framework_TestCase
@@ -135,5 +136,15 @@ class AbstractEnumTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertTrue(DummyEnum::isValidValue(42));
         $this->assertFalse(DummyEnum::isValidValue('42'));
+    }
+
+    public function testSimpleKeyFromValue()
+    {
+        $this->assertSame('FIRST', DummyEnum::getKeysFromValue(42));
+    }
+
+    public function testMultiKeysFromValue()
+    {
+        $this->assertSame(['FIRST', 'SECOND'], DummyWithSameValuesEnum::getKeysFromValue(42));
     }
 }

--- a/test/Fixtures/DummyWithSameValuesEnum.php
+++ b/test/Fixtures/DummyWithSameValuesEnum.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Greg0ire\Enum\Tests\Fixtures;
+
+use Greg0ire\Enum\AbstractEnum;
+
+final class DummyWithSameValuesEnum extends AbstractEnum
+{
+    const FIRST = 42;
+    const SECOND = 42;
+}


### PR DESCRIPTION
This method returns the key or an array of keys for a value.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/greg0ire/enum/issues/66
| License       | MIT