### PR TITLE
Port some AbstractEnum methods to Twig functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,10 +214,12 @@ $view = $this->factory->create(EnumType::class, null, array(
 
 #### Twig extension
 
-This package comes with an `enum_label` filter, available thanks to the `EnumExtension` Twig class.
+This package comes with an `EnumExtension` Twig class. It contains a filter and some functions.
 You have to require the `twig/twig` package to get it working.
 
-The filter will try to return the constant label corresponding to the given value.
+##### Filter
+
+The `enum_label` filter will try to return the constant label corresponding to the given value.
 
 It will try to translate it if possible. To enable translation, require the `symfony/translation` component
 and pass a `Symfony\Component\Translation\TranslationInterface` instance on the `EnumExtension` constructor.
@@ -232,6 +234,24 @@ Usage:
 {{ value|enum_label('Your\\Enum\\Class', false) }} {# Disable translation. In this case the class prefix wont be added #}
 {{ value|enum_label('Your\\Enum\\Class', false, true) }} {# Disable translation but keep class prefix #}
 {{ value|enum_label('Your\\Enum\\Class', false, true, '.') }} {# Disable translation but keep class prefix with a custom separator #}
+```
+
+##### Functions
+
+The 3 available twig functions are ports of some `AbstractEnum` methods that can be useful in a twig template:
+
+* `enum_get_constants` => `AbstractEnum::getConstants`
+* `enum_get_keys` => `AbstractEnum::getKeys`
+* `enum_get_class_prefixed_keys` => `AbstractEnum::getClassPrefixedKeys`
+
+The arguments are exactly the same except you have to specify the targeted class first (as `enum_label` filter).
+
+Here is a concrete example with `enum_get_constants` function:
+
+```twig
+{% for enum_key, enum_value in enum_get_constants('Your\\Enum\\Class') %}
+    {{ enum_key }} -> {{ enum_value }}
+{% endfor %}
 ```
 
 ##### Twig extension as a service

--- a/src/Bridge/Twig/Extension/EnumExtension.php
+++ b/src/Bridge/Twig/Extension/EnumExtension.php
@@ -2,6 +2,7 @@
 
 namespace Greg0ire\Enum\Bridge\Twig\Extension;
 
+use Greg0ire\Enum\AbstractEnum;
 use Symfony\Component\Translation\TranslatorInterface;
 
 /**
@@ -29,6 +30,18 @@ final class EnumExtension extends \Twig_Extension
     {
         return [
             new \Twig_SimpleFilter('enum_label', [$this, 'label']),
+        ];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getFunctions()
+    {
+        return [
+            new \Twig_SimpleFunction('enum_get_constants', [$this, 'getConstants']),
+            new \Twig_SimpleFunction('enum_get_keys', [$this, 'getKeys']),
+            new \Twig_SimpleFunction('enum_get_class_prefixed_keys', [$this, 'getClassPrefixedKeys']),
         ];
     }
 
@@ -71,6 +84,48 @@ final class EnumExtension extends \Twig_Extension
         }
 
         return $label;
+    }
+
+    /**
+     * @see AbstractEnum::getConstants()
+     *
+     * @param string $class
+     * @param callable|null $keysCallback
+     * @param bool          $classPrefixed
+     * @param string        $namespaceSeparator
+     *
+     * @return array
+     */
+    public function getConstants($class, $keysCallback = null, $classPrefixed = false, $namespaceSeparator = null)
+    {
+        return call_user_func([$class, 'getConstants'], $keysCallback, $classPrefixed, $namespaceSeparator);
+    }
+
+    /**
+     * @see AbstractEnum::getKeys()
+     *
+     * @param string $class
+     * @param $callback|null $callback
+     *
+     * @return array
+     */
+    public function getKeys($class, $callback = null)
+    {
+        return call_user_func([$class, 'getKeys'], $callback);
+    }
+
+    /**
+     * @see AbstractEnum::getClassPrefixedKeys()
+     *
+     * @param string $class
+     * @param callable|null $callback
+     * @param string|null $namespaceSeparator
+     *
+     * @return mixed
+     */
+    public function getClassPrefixedKeys($class, $callback = null, $namespaceSeparator = null)
+    {
+        return call_user_func([$class, 'getClassPrefixedKeys'], $callback, $namespaceSeparator);
     }
 
     /**

--- a/test/Bridge/Twig/Extension/EnumExtensionTest.php
+++ b/test/Bridge/Twig/Extension/EnumExtensionTest.php
@@ -77,4 +77,40 @@ final class EnumExtensionTest extends \PHPUnit_Framework_TestCase
             'Without any available translation, the filter should just return the key.'
         );
     }
+
+    public function testGetConstants()
+    {
+        $this->assertSame(
+            [
+                'GOD' => 'Dieu',
+                'CHUCK' => 'Chuck Norris',
+                'GUITRY' => 'Sacha Guitry',
+            ],
+            $this->extension->getConstants(FooEnum::class)
+        );
+    }
+
+    public function testGetKeys()
+    {
+        $this->assertSame(
+            [
+                'GOD',
+                'CHUCK',
+                'GUITRY',
+            ],
+            $this->extension->getKeys(FooEnum::class)
+        );
+    }
+
+    public function testGetClassPrefixedKeys()
+    {
+        $this->assertSame(
+            [
+                'greg0ire_enum_tests_fixtures_foo_enum_GOD',
+                'greg0ire_enum_tests_fixtures_foo_enum_CHUCK',
+                'greg0ire_enum_tests_fixtures_foo_enum_GUITRY',
+            ],
+            $this->extension->getClassPrefixedKeys(FooEnum::class)
+        );
+    }
 }


### PR DESCRIPTION
Those methods can be useful especially for enum iterating from a Twig template.

Ported methods:

- AbstractEnum::getConstants
- AbstractEnum::getKeys
- AbstractEnum::getClassPrefixedKeys