### PR TITLE
Use compiler pass to check if the translator exists

### DIFF
--- a/src/Bridge/Symfony/Bundle/Greg0ireEnumBundle.php
+++ b/src/Bridge/Symfony/Bundle/Greg0ireEnumBundle.php
@@ -2,7 +2,9 @@
 
 namespace Greg0ire\Enum\Bridge\Symfony\Bundle;
 
+use Greg0ire\Enum\Bridge\Symfony\DependencyInjection\Compiler\TranslatorCompilerPass;
 use Greg0ire\Enum\Bridge\Symfony\DependencyInjection\Greg0ireEnumExtension;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 /**
@@ -10,6 +12,18 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
  */
 final class Greg0ireEnumBundle extends Bundle
 {
+    /**
+     * {@inheritdoc}
+     */
+    public function build(ContainerBuilder $container)
+    {
+        parent::build($container);
+
+        $container
+            ->addCompilerPass(new TranslatorCompilerPass())
+        ;
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/src/Bridge/Symfony/DependencyInjection/Compiler/TranslatorCompilerPass.php
+++ b/src/Bridge/Symfony/DependencyInjection/Compiler/TranslatorCompilerPass.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Greg0ire\Enum\Bridge\Symfony\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * @author Sullivan Senechal <soullivaneuh@gmail.com>
+ */
+final class TranslatorCompilerPass implements CompilerPassInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        if (class_exists(\Twig_Extension::class) && $container->hasDefinition('translator.default')) {
+            $container->getDefinition('greg0ire_enum.twig.extension.enum')
+                ->addArgument(new Reference('translator.default'));
+        }
+    }
+}

--- a/src/Bridge/Symfony/DependencyInjection/Greg0ireEnumExtension.php
+++ b/src/Bridge/Symfony/DependencyInjection/Greg0ireEnumExtension.php
@@ -2,12 +2,10 @@
 
 namespace Greg0ire\Enum\Bridge\Symfony\DependencyInjection;
 
-use Symfony\Bundle\FrameworkBundle\Translation\Translator;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
-use Symfony\Component\DependencyInjection\Reference;
 
 /**
  * @author Sullivan Senechal <soullivaneuh@gmail.com>
@@ -23,11 +21,6 @@ final class Greg0ireEnumExtension extends Extension
 
         if (class_exists(\Twig_Extension::class)) {
             $loader->load('twig.xml');
-
-            if ($container->hasDefinition('translator.default')) {
-                $container->getDefinition('greg0ire_enum.twig.extension.enum')
-                    ->addArgument(new Reference('translator.default'));
-            }
         }
     }
 }

--- a/test/Bridge/Symfony/DependencyInjection/Compiler/TranslatorCompilerPassTest.php
+++ b/test/Bridge/Symfony/DependencyInjection/Compiler/TranslatorCompilerPassTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Greg0ire\Enum\Tests\Bridge\Symfony\DependencyInjection\Compiler;
+
+use Greg0ire\Enum\Tests\Fixtures\AppKernel;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Translation\TranslatorInterface;
+
+/**
+ * @author Sullivan Senechal <soullivaneuh@gmail.com>
+ *
+ * We have to make a kernel test case because the hasDefinition check didn't work on the extension class.
+ */
+final class TranslatorCompilerPassTest extends KernelTestCase
+{
+    public function testTwigExtensionHasTheTranslator()
+    {
+        static::bootKernel();
+
+        static::assertAttributeInstanceOf(
+            TranslatorInterface::class,
+            'translator',
+            self::$kernel->getContainer()->get('greg0ire_enum.twig.extension.enum')
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected static function getKernelClass()
+    {
+        return AppKernel::class;
+    }
+}

--- a/test/Bridge/Symfony/DependencyInjection/Greg0ireEnumExtensionTest.php
+++ b/test/Bridge/Symfony/DependencyInjection/Greg0ireEnumExtensionTest.php
@@ -6,7 +6,6 @@ use Greg0ire\Enum\Bridge\Symfony\DependencyInjection\Greg0ireEnumExtension;
 use Greg0ire\Enum\Bridge\Twig\Extension\EnumExtension;
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\FrameworkExtension;
-use Symfony\Component\DependencyInjection\Reference;
 
 /**
  * @author Sullivan Senechal <soullivaneuh@gmail.com>
@@ -40,11 +39,6 @@ final class Greg0ireEnumExtensionTest extends AbstractExtensionTestCase
         $this->assertContainerBuilderHasService(
             'greg0ire_enum.twig.extension.enum',
             EnumExtension::class
-        );
-        $this->assertContainerBuilderHasServiceDefinitionWithArgument(
-            'greg0ire_enum.twig.extension.enum',
-            0,
-            new Reference('translator.default')
         );
     }
 

--- a/test/Fixtures/AppKernel.php
+++ b/test/Fixtures/AppKernel.php
@@ -1,0 +1,48 @@
+<?php
+
+
+namespace Greg0ire\Enum\Tests\Fixtures;
+
+use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\HttpKernel\Kernel;
+
+/**
+ * @author Sullivan Senechal <soullivaneuh@gmail.com>
+ */
+final class AppKernel extends Kernel
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function registerBundles()
+    {
+        return [
+            new \Symfony\Bundle\FrameworkBundle\FrameworkBundle(),
+            new \Greg0ire\Enum\Bridge\Symfony\Bundle\Greg0ireEnumBundle(),
+        ];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function registerContainerConfiguration(LoaderInterface $loader)
+    {
+        $loader->load(__DIR__.'/config.yml');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getCacheDir()
+    {
+        return sys_get_temp_dir().'/greg0ire/enum/cache';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getLogDir()
+    {
+        return sys_get_temp_dir().'/greg0ire/enum/logs';
+    }
+}

--- a/test/Fixtures/config.yml
+++ b/test/Fixtures/config.yml
@@ -1,0 +1,4 @@
+framework:
+  secret: 'This is very secret. I am Batman.'
+  translator:
+    fallbacks: ['en']


### PR DESCRIPTION
This is more reliable because the translator is built before the
compiler passes execution.

Plus, we can even change priority for any possible future issues.

Fixes #93 
Closes #94