### PR TITLE
Bump supported versions of sf

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,12 +25,14 @@ matrix:
     - php: 7.1
       env: SYMFONY_VERSION=2.8.*
     - php: 7.1
-      env: SYMFONY_VERSION=3.1.*
-    - php: 7.1
       env: SYMFONY_VERSION=3.2.*
+    - php: 7.1
+      env: SYMFONY_VERSION=3.3.*
+    - php: 7.1
+      env: SYMFONY_VERSION=3.4.*@dev
   allow_failures:
     - php: nightly
-    - env: SYMFONY_VERSION=3.3.*@dev
+    - env: SYMFONY_VERSION=3.4.*@dev
 
 install:
   - composer global require sllh/composer-lint:@stable --prefer-dist --no-interaction


### PR DESCRIPTION
3.1 is end of life, and 3.4 should be available soonish.