### PR TITLE
Require dev dependencies

### DIFF
--- a/.github/workflows/sa.yml
+++ b/.github/workflows/sa.yml
@@ -8,5 +8,7 @@ jobs:
       - uses: actions/checkout@master
       - name: OSKAR-phpstan
         uses: "docker://oskarstark/phpstan-ga"
+        env:
+          REQUIRE_DEV: true
         with:
           args: analyse src/ --level=3


### PR DESCRIPTION
Some of these are actually optional dependencies and PHPStan needs to
know about them to fully understand the code.