### PR TITLE
fix(137): change FQN class in services + rename id of the service + tweak tests + update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ the `GetLabel` class and invoke it.
 use Greg0ire\Enum\Bridge\Symfony\Translator\GetLabel;
 
 $label = new GetLabel();
-$label($value, 'Your\Enum\Class');
+$label(Your\Enum\Class::VALUE, Your\Enum\Class::class);
 ```
 
 To enable translation, require the `symfony/translation` component
@@ -169,26 +169,26 @@ use Greg0ire\Enum\Bridge\Symfony\Translator\GetLabel;
 use Symfony\Contracts\Translation\TranslationInterface;
 
 $label = new GetLabel($translator);
-$label($value, 'Your\Enum\Class');
+$label(Your\Enum\Class::VALUE, Your\Enum\Class::class);
 ```
 
-If you're using Symfony, tag the service and simply inject it.
+If you're using Symfony, alias the service and simply inject it.
 If translations are enabled, the `TranslatorInterface` will be automatically injected.
 
 ```yaml
 services:
     # ...
-    Greg0ire\Enum\Bridge\Symfony\Translator\Label: "@greg0ire_enum.symfony.translator.label"
+    Greg0ire\Enum\Bridge\Symfony\Translator\GetLabel: "@greg0ire_enum.symfony.translator.get_label"
 ```
 
 ```php
 public function index(GetLabel $label)
 {
-    $label($value, 'Your\Enum\Class');
-    $label($value, 'Your\Enum\Class', 'another_domain'); // Change the translation domain
-    $label($value, 'Your\Enum\Class', false); // Disable translation. In this case the class prefix wont be added
-    $label($value, 'Your\Enum\Class', false, true); // Disable translation but keep class prefix
-    $label($value, 'Your\Enum\Class', false, true, '.'); // Disable translation but keep class prefix with a custom separator
+    $label(Your\Enum\Class::VALUE, Your\Enum\Class::class);
+    $label(Your\Enum\Class::VALUE, Your\Enum\Class::class, 'another_domain'); // Change the translation domain
+    $label(Your\Enum\Class::VALUE, Your\Enum\Class::class, false); // Disable translation. In this case the class prefix wont be added
+    $label(Your\Enum\Class::VALUE, Your\Enum\Class::class, false, true); // Disable translation but keep class prefix
+    $label(Your\Enum\Class::VALUE, Your\Enum\Class::class, false, true, '.'); // Disable translation but keep class prefix with a custom separator
 }
 ```
 

--- a/src/Bridge/Symfony/DependencyInjection/Compiler/TranslatorCompilerPass.php
+++ b/src/Bridge/Symfony/DependencyInjection/Compiler/TranslatorCompilerPass.php
@@ -18,7 +18,7 @@ final class TranslatorCompilerPass implements CompilerPassInterface
     public function process(ContainerBuilder $container): void
     {
         if (class_exists(AbstractExtension::class) && $container->hasDefinition('translator.default')) {
-            $container->getDefinition('greg0ire_enum.symfony.translator.label')
+            $container->getDefinition('greg0ire_enum.symfony.translator.get_label')
                 ->addArgument(new Reference('translator.default'));
         }
     }

--- a/src/Bridge/Symfony/Resources/config/services.xml
+++ b/src/Bridge/Symfony/Resources/config/services.xml
@@ -6,7 +6,7 @@
     <services>
         <defaults public="false" />
 
-        <service id="greg0ire_enum.symfony.translator.label" class="Greg0ire\Enum\Bridge\Symfony\Translator\Label" public="true">
+        <service id="greg0ire_enum.symfony.translator.get_label" class="Greg0ire\Enum\Bridge\Symfony\Translator\GetLabel" public="true">
             <argument type="service" id="translator.default" />
         </service>
 

--- a/src/Bridge/Symfony/Resources/config/twig.xml
+++ b/src/Bridge/Symfony/Resources/config/twig.xml
@@ -6,6 +6,7 @@
     <services>
         <service id="greg0ire_enum.twig.extension.enum" class="Greg0ire\Enum\Bridge\Twig\Extension\EnumExtension">
             <tag name="twig.extension"/>
+            <argument type="service" id="greg0ire_enum.symfony.translator.get_label" />
         </service>
     </services>
 </container>

--- a/tests/Bridge/Symfony/DependencyInjection/Greg0ireEnumExtensionTest.php
+++ b/tests/Bridge/Symfony/DependencyInjection/Greg0ireEnumExtensionTest.php
@@ -74,7 +74,7 @@ final class Greg0ireEnumExtensionTest extends AbstractExtensionTestCase
         $compilerPass->process($this->container);
 
         $this->assertContainerBuilderHasServiceDefinitionWithArgument(
-            'greg0ire_enum.symfony.translator.label',
+            'greg0ire_enum.symfony.translator.get_label',
             0,
             new Reference('translator.default')
         );


### PR DESCRIPTION
Refer to previous PR #138 

Sorry @greg0ire, the FQN on `services.yaml` + docs (alias) was still the previous one (`Label` vs `GetLabel`).

I took the opportunity to also rename the id of the service to keep the same naming conventions.

I'll update your bundle on my project with the [v4.2.0](https://github.com/greg0ire/enum/releases/tag/v4.2.0) to ensure everything is working good, don't merge too fast ;)